### PR TITLE
スクロール後に選択した日付がリセットされるバグを解消

### DIFF
--- a/lib/app/work/presentation/widget/date_select_button.dart
+++ b/lib/app/work/presentation/widget/date_select_button.dart
@@ -25,15 +25,16 @@ class DateSelectButton extends StatefulWidget {
 
 class DateSelectButtonState extends State<DateSelectButton>
     with AutomaticKeepAliveClientMixin {
+  static final targetDateFormatter = DateFormat('yyyy/MM/dd');
+
   @override
   bool get wantKeepAlive => true;
 
   @override
   Widget build(BuildContext context) {
     super.build(context);
-    return Consumer(builder: (context, ref, child) {
-      final targetDateFormatter = DateFormat('yyyy/MM/dd');
 
+    return Consumer(builder: (context, ref, child) {
       // providerを使ってtargetDateを取得
       final targetDate = ref.watch(workDateNotifierProvider);
 
@@ -76,12 +77,17 @@ class DateSelectButtonState extends State<DateSelectButton>
         }).toList();
       }
 
+      // テストを実施しやすくするためメソッドを切り分け
+      DateTime getFutureDate() {
+        return DateTime.now().add(const Duration(days: 360));
+      }
+
       Future<void> selectDate(BuildContext context) async {
         final DateTime? picked = await showDatePicker(
             context: context,
             initialDate: targetDate,
             firstDate: DateTime(2016),
-            lastDate: DateTime.now().add(const Duration(days: 360)));
+            lastDate: getFutureDate());
         if (picked != null && picked != targetDate) {
           final notifier = ref.read(workDateNotifierProvider.notifier);
           notifier.updateState(picked);

--- a/lib/app/work/presentation/widget/date_select_button.dart
+++ b/lib/app/work/presentation/widget/date_select_button.dart
@@ -11,98 +11,111 @@ import 'package:work_log/app/work/application/state/work_input_list.dart';
 import 'package:work_log/app/work/application/work_list_usecase.dart';
 import 'package:work_log/app/work/presentation/widget/work_input_row.dart';
 
-class DateSelectButton extends ConsumerWidget {
+class DateSelectButton extends StatefulWidget {
   final ValueNotifier<List<InProgressProduct>> productList;
 
   const DateSelectButton({
-    super.key,
+    Key? key,
     required this.productList,
-  });
+  }) : super(key: key);
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final targetDateFormatter = DateFormat('yyyy/MM/dd');
+  DateSelectButtonState createState() => DateSelectButtonState();
+}
 
-    // providerを使ってtargetDateを取得
-    final targetDate = ref.watch(workDateNotifierProvider);
+class DateSelectButtonState extends State<DateSelectButton>
+    with AutomaticKeepAliveClientMixin {
+  @override
+  bool get wantKeepAlive => true;
 
-    List<WorkInputRow> convertWorkListToInputWorkList(List<Work> workList) {
-      return workList.asMap().entries.map((entry) {
-        final index = entry.key;
-        final work = entry.value;
-        // 進行中の商品名のドロップダウンリストを作成
-        final dropDownButtonMenu = <int, String>{};
+  @override
+  Widget build(BuildContext context) {
+    super.build(context);
+    return Consumer(builder: (context, ref, child) {
+      final targetDateFormatter = DateFormat('yyyy/MM/dd');
 
-        for (final product in productList.value) {
-          dropDownButtonMenu[product.id!] = product.productName;
-        }
+      // providerを使ってtargetDateを取得
+      final targetDate = ref.watch(workDateNotifierProvider);
 
-        // 未登録の商品をドロップダウンリストに追加
-        if (productList.value
-            .where((element) => element.id == work.productId)
-            .isEmpty) {
-          dropDownButtonMenu[work.productId] = work.productName!;
-        }
+      List<WorkInputRow> convertWorkListToInputWorkList(List<Work> workList) {
+        return workList.asMap().entries.map((entry) {
+          final index = entry.key;
+          final work = entry.value;
+          // 進行中の商品名のドロップダウンリストを作成
+          final dropDownButtonMenu = <int, String>{};
 
-        // 商品IDのstateを更新
-        final notifier =
-            ref.read(selectedProductIdNotifierProvider(index).notifier);
-        notifier.updateState(work.productId);
+          for (final product in widget.productList.value) {
+            dropDownButtonMenu[product.id!] = product.productName;
+          }
 
-        // 商品IDのstateを更新
-        final dropDownButtonNotifier = ref.read(
-            ProductDropDownButtonItemListNotifierProvider(index).notifier);
-        dropDownButtonNotifier.updateState(dropDownButtonMenu);
+          // 未登録の商品をドロップダウンリストに追加
+          if (widget.productList.value
+              .where((element) => element.id == work.productId)
+              .isEmpty) {
+            dropDownButtonMenu[work.productId] = work.productName!;
+          }
 
-        return WorkInputRow(
-          workId: work.id,
-          workDateTime: work.workDateTime,
-          workDetailController: work.workDetailController,
-          workMemoController: work.workMemoController,
-          productName: work.productName!,
-          index: index,
-        );
-      }).toList();
-    }
+          // 商品IDのstateを更新
+          final notifier =
+              ref.read(selectedProductIdNotifierProvider(index).notifier);
+          notifier.updateState(work.productId);
 
-    Future<void> selectDate(BuildContext context) async {
-      final DateTime? picked = await showDatePicker(
-          context: context,
-          initialDate: targetDate,
-          firstDate: DateTime(2016),
-          lastDate: DateTime.now().add(const Duration(days: 360)));
-      if (picked != null && picked != targetDate) {
-        final notifier = ref.read(workDateNotifierProvider.notifier);
-        notifier.updateState(picked);
+          // 商品IDのstateを更新
+          final dropDownButtonNotifier = ref.read(
+              ProductDropDownButtonItemListNotifierProvider(index).notifier);
+          dropDownButtonNotifier.updateState(dropDownButtonMenu);
 
-        // targetDateが更新されたら、inputWorkListも更新する
-        final workList =
-            await GetIt.I<WorkListUsecase>().fetchWorkListByDate(picked);
-
-        // workListの内容をinputWorkListへ詰め替える
-        final workInputListNotifier = ref.read(workInputListProvider.notifier);
-        workInputListNotifier
-            .setState(convertWorkListToInputWorkList(workList));
+          return WorkInputRow(
+            workId: work.id,
+            workDateTime: work.workDateTime,
+            workDetailController: work.workDetailController,
+            workMemoController: work.workMemoController,
+            productName: work.productName!,
+            index: index,
+          );
+        }).toList();
       }
-    }
 
-    return Row(
-      children: [
-        Flexible(
-          child: Padding(
-            padding: const EdgeInsets.all(8.0),
-            child: Text(targetDateFormatter.format(targetDate)),
+      Future<void> selectDate(BuildContext context) async {
+        final DateTime? picked = await showDatePicker(
+            context: context,
+            initialDate: targetDate,
+            firstDate: DateTime(2016),
+            lastDate: DateTime.now().add(const Duration(days: 360)));
+        if (picked != null && picked != targetDate) {
+          final notifier = ref.read(workDateNotifierProvider.notifier);
+          notifier.updateState(picked);
+
+          // targetDateが更新されたら、inputWorkListも更新する
+          final workList =
+              await GetIt.I<WorkListUsecase>().fetchWorkListByDate(picked);
+
+          // workListの内容をinputWorkListへ詰め替える
+          final workInputListNotifier =
+              ref.read(workInputListProvider.notifier);
+          workInputListNotifier
+              .setState(convertWorkListToInputWorkList(workList));
+        }
+      }
+
+      return Row(
+        children: [
+          Flexible(
+            child: Padding(
+              padding: const EdgeInsets.all(8.0),
+              child: Text(targetDateFormatter.format(targetDate)),
+            ),
           ),
-        ),
-        Flexible(
-          child: Padding(
-            padding: const EdgeInsets.all(8.0),
-            child: ElevatedButton(
-                onPressed: () => selectDate(context),
-                child: const Text('日付選択')),
+          Flexible(
+            child: Padding(
+              padding: const EdgeInsets.all(8.0),
+              child: ElevatedButton(
+                  onPressed: () => selectDate(context),
+                  child: const Text('日付選択')),
+            ),
           ),
-        ),
-      ],
-    );
+        ],
+      );
+    });
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新機能**
    - `DateSelectButton` クラスを `ConsumerWidget` から `StatefulWidget` に変更しました。
    - `build` メソッドを別の `DateSelectButtonState` クラスに移動しました。
    - 日付選択に関するロジックを `DateSelectButtonState` クラス内にリファクタリングしました。
    - 選択された日付や製品リストに基づいてステートやUI要素を更新するロジックを改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->