### PR TITLE
デバッグモードの際にUIを切り替え

### DIFF
--- a/lib/app/work/application/state/selected_product_id_notifier.dart
+++ b/lib/app/work/application/state/selected_product_id_notifier.dart
@@ -21,7 +21,7 @@ class SelectedProductIdNotifier extends _$SelectedProductIdNotifier {
     if (productIdList.isEmpty) {
       return -1;
     }
-    return productIdList.first.id!;
+    return productIdList.last.id!;
   }
 
   void updateState(int productId) {

--- a/lib/app/work/presentation/pages/work_list.dart
+++ b/lib/app/work/presentation/pages/work_list.dart
@@ -27,7 +27,7 @@ class WorkList extends HookConsumerWidget {
       return null;
     }, []);
 
-    const title = kReleaseMode ? '作業入力画面' : '作業入力画面（開発環境）';
+    const title = kDebugMode ? '作業入力画面（デバッグ環境）' : '作業入力画面';
 
     return Scaffold(
       appBar: AppBar(title: const Text(title)),

--- a/lib/app/work/presentation/widget/work_input_row.dart
+++ b/lib/app/work/presentation/widget/work_input_row.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:work_log/app/domain/config/work_config.dart';
@@ -6,7 +7,7 @@ import 'package:work_log/app/work/presentation/widget/product_drop_down_button.d
 class WorkInputRow extends StatefulWidget {
   final int? workId;
   final DateTime workDateTime;
-  final List<int> flexRate = [1, 3, 3, 3];
+  final List<int> flexRate = kDebugMode ? [1, 2, 2, 4, 4] : [1, 3, 3, 3];
   final TextEditingController workDetailController;
   final TextEditingController workMemoController;
   final DateFormat formatter = DateFormat('HH:mm');
@@ -42,15 +43,16 @@ class WorkInputRowState extends State<WorkInputRow>
 
     return Row(
       children: <Widget>[
-        // TODO : IDは最後に消す
-        Expanded(
-          flex: 1,
-          child: Container(
-            padding: const EdgeInsets.all(10),
-            child:
-                Text(widget.workId == null ? 'null' : widget.workId.toString()),
+        if (kDebugMode)
+          Expanded(
+            flex: 1,
+            child: Container(
+              padding: const EdgeInsets.all(10),
+              child: Text(
+                  widget.workId == null ? 'null' : widget.workId.toString()),
+            ),
           ),
-        ),
+        // kDebugMode
         Expanded(
           flex: widget.flexRate[0],
           child: Container(
@@ -63,9 +65,7 @@ class WorkInputRowState extends State<WorkInputRow>
           child: Container(
             padding: const EdgeInsets.symmetric(horizontal: 5),
             child: ProductDropDownButton(
-                before30Days: widget.workDateTime
-                    .isAfter(DateTime.now().subtract(const Duration(days: 30))),
-                index: widget.index),
+                before30Days: before30Days, index: widget.index),
           ),
         ),
         Expanded(

--- a/lib/app/work/presentation/widget/work_input_table.dart
+++ b/lib/app/work/presentation/widget/work_input_table.dart
@@ -1,10 +1,13 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:work_log/app/work/application/state/work_input_list.dart';
 
 class WorkInputTable extends ConsumerWidget {
-  static const header = <String>['ID', '時間', '商品名', '作業内容', '作業メモ'];
-  static const flexRate = <int>[1, 2, 2, 4, 4];
+  static const header = kDebugMode
+      ? ['ID', '時間', '商品名', '作業内容', '作業メモ']
+      : ['時間', '商品名', '作業内容', '作業メモ'];
+  static const flexRate = kDebugMode ? [1, 2, 2, 4, 4] : [1, 3, 3, 3];
   const WorkInputTable({super.key});
 
   Widget buildHeader() {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- リストの最後の製品IDを返すように製品IDの取得ロジックを変更しました。
	- アプリのタイトルをデバッグモードとリリースモードに基づいて更新し、環境をより正確に反映させるようにしました。
	- `kDebugMode`を使用して、条件に応じて`WorkInputRow`の`flexRate`リストを設定し、ウィジェットのレンダリングを変更しました。
	- デバッグモードに基づいて、`WorkInputTable`の`header`と`flexRate`定数を条件付きで定義し、表示されるテーブルヘッダーと列のフレックス率に影響を与えました。

- **バグ修正**
	- 特になし

- **ドキュメンテーション**
	- 特になし

- **リファクタ**
	- 特になし

- **スタイル**
	- 特になし

- **テスト**
	- 特になし

- **チョア**
	- 特になし

- **リバート**
	- 特になし

<!-- end of auto-generated comment: release notes by coderabbit.ai -->